### PR TITLE
Create tmpdir incase it is not created in subroutines.

### DIFF
--- a/niftypet/nipet/img/mmrimg.py
+++ b/niftypet/nipet/img/mmrimg.py
@@ -472,6 +472,7 @@ def align_mumap(
 
     #> tmp folder for not aligned mu-maps
     tmpdir = os.path.join(opth, 'tmp')
+    nimpa.create_dir(tmpdir)
 
     #> get the timing of PET if affine not given
     if faff=='' and not hst is None and isinstance(hst, dict) and 't0' in hst:


### PR DESCRIPTION
In some cases in align_mumap the tmpdir is not created before it is used to store pre-aligned data. This just ensures it is created just in case. 