### PR TITLE
Add image-space resolution modelling using Gaussian PSF

### DIFF
--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -205,7 +205,7 @@
     "    histo=m,\n",
     "    mu_h=mu_h,\n",
     "    mu_o=mu_o,\n",
-    "    fwhm=2.5,\n",
+    "    fwhm_rm=2.5,\n",
     "    outpath=opth,\n",
     "    fcomment=\"niftypet-recon\",\n",
     "    store_img=True)\n",

--- a/niftypet/nipet/img/pipe.py
+++ b/niftypet/nipet/img/pipe.py
@@ -35,6 +35,7 @@ def mmrchain(
 
     itr=4,          # number of OSEM iterations
     fwhm=0.,        # Gaussian Smoothing FWHM
+    fwhm_rm=0.,     # Resolution Modelling
     recmod = -1,    # reconstruction mode: -1: undefined, chosen
                     # automatically. 3: attenuation and scatter
                     # correction, 1: attenuation correction
@@ -343,7 +344,7 @@ def mmrchain(
         # run OSEM reconstruction of a single time frame
         recimg = mmrrec.osemone(datain, [muhd['im'], muo],
                                 hst, scanner_params,
-                                recmod=recmod, itr=itr, fwhm=fwhm,
+                                recmod=recmod, itr=itr, fwhm=fwhm, fwhm_rm=fwhm_rm,
                                 outpath=petimg,
                                 frmno=frmno,
                                 fcomment=fcomment+'_i',
@@ -362,14 +363,14 @@ def mmrchain(
         if nfrm==1: output['tuple'] = recimg
 
     output['im'] = np.squeeze(dynim)
-    
+
     if ret_sinos and itr>1 and recmod>2:
         output['sinos'] = {
             'psino':dynpsn,
             'ssino':dynssn,
             'rsino':dynrsn,
             'amask':dynmsk}
-    
+
     if ret_histo:
         output['hst'] = hsts
 
@@ -482,6 +483,7 @@ def mmrchain(
                     +';sub=14'                      \
                     +';itr='+str(itr)               \
                     +';fwhm='+str(fwhm)             \
+                    +';fwhm_rm='+str(fwhm_rm)       \
                     +';nfrm='+str(nfrm)
 
         # squeeze the not needed dimensions

--- a/niftypet/nipet/prj/mmrrec.py
+++ b/niftypet/nipet/prj/mmrrec.py
@@ -275,7 +275,6 @@ def osemone(datain, mumaps, hst, scanner_params,
         disable=log.getEffectiveLevel() > logging.INFO,
         leave=log.getEffectiveLevel() <= logging.INFO
     ) as pbar:
-        Cnt = Cnt.copy()
         # resolution modelling
         Cnt['SIGMA_RM'] = fwhm2sig(fwhm_rm, Cnt) if fwhm_rm else 0
         for k in pbar:

--- a/niftypet/nipet/prj/mmrrec.py
+++ b/niftypet/nipet/prj/mmrrec.py
@@ -95,16 +95,16 @@ def get_subsets14(n, params):
 
 
 def osemone(datain, mumaps, hst, scanner_params,
-            recmod=3, itr=4, fwhm=0., mask_radius=29.,
+            recmod=3, itr=4, fwhm=0., fwhm_rm=0., mask_radius=29.,
             sctsino=np.array([]),
             outpath='',
             store_img=False, frmno='', fcomment='',
             store_itr=[],
             emmskS=False,
             ret_sinos=False,
-            attnsino = None,
-            randsino = None,
-            normcomp = None):
+            attnsino=None,
+            randsino=None,
+            normcomp=None):
     """
     OSEM image reconstruction with several modes
     (with/without scatter and/or attenuation correction)
@@ -273,8 +273,11 @@ def osemone(datain, mumaps, hst, scanner_params,
     #-------------------------------------------------------------------------
     with trange(itr, desc="OSEM",
         disable=log.getEffectiveLevel() > logging.INFO,
-        leave=log.getEffectiveLevel() <= logging.INFO) as pbar:
-
+        leave=log.getEffectiveLevel() <= logging.INFO
+    ) as pbar:
+        Cnt = Cnt.copy()
+        # resolution modelling
+        Cnt['SIGMA_RM'] = fwhm2sig(fwhm_rm, Cnt) if fwhm_rm else 0
         for k in pbar:
             petprj.osem(img, msk, psng, rsng, ssng, nsng, asng, imgsens, txLUT, axLUT, sinoTIdx, Cnt)
             if np.nansum(img) < 0.1:

--- a/niftypet/nipet/prj/mmrsim.py
+++ b/niftypet/nipet/prj/mmrsim.py
@@ -289,6 +289,7 @@ def simulate_recon(
         #> sensitivity image for the EM-ML reconstruction
         sim = mmrprj.back_prj(attsino, scanner_params)
         sim_inv = 1 / psf(sim)
+        sim_inv[~msk] = 0
 
         rndsct = rsng + ssng
         for i in trange(nitr, desc="MLEM",
@@ -304,10 +305,8 @@ def simulate_recon(
             bim = psf(mmrprj.back_prj(crrsino, scanner_params))
 
             #> divide the back-projected image by the sensitivity image
-            bim *= sim_inv
-
             #> update the estimated image and remove NaNs
-            eim *= msk*bim
+            eim *= bim * sim_inv
             eim[np.isnan(eim)] = 0
 
     return eim

--- a/niftypet/nipet/prj/mmrsim.py
+++ b/niftypet/nipet/prj/mmrsim.py
@@ -1,8 +1,9 @@
 """Simulations for image reconstruction with recommended reduced axial field of view"""
 import logging
 
-import numpy as np
+from scipy import ndimage as ndi
 from tqdm.auto import trange
+import numpy as np
 
 from ..img import mmrimg
 from .. import mmraux
@@ -119,7 +120,8 @@ def simulate_recon(
     ctim,
     scanner_params,
     simulate_3d = False,
-    nitr = 60,
+    nitr=60,
+    fwhm_rm=0.,
     slice_idx = -1,
     randoms=None,
     scatter=None,
@@ -215,6 +217,8 @@ def simulate_recon(
     else:
         ssng = 1e-5*np.ones((Cnt['Naw'], nsinos), dtype=np.float32)
 
+    # resolution modelling
+    Cnt['SIGMA_RM'] = fwhm2sig(fwhm_rm, Cnt) if fwhm_rm else 0
 
     if simulate_3d:
         log.debug('------ OSEM (%d) -------' % nitr)
@@ -272,6 +276,11 @@ def simulate_recon(
         eim = mmrimg.convert2e7(eimg, Cnt)
 
     else:
+        def psf(x):
+            if Cnt['SIGMA_RM']:
+                ndi.gaussian_filter(x, sigma=Cnt['SIGMA_RM'], mode='constant', output=x)
+            return x
+
         #> estimated image, initialised to ones
         eim = np.ones(rmu.shape, dtype=np.float32)
 
@@ -279,6 +288,7 @@ def simulate_recon(
 
         #> sensitivity image for the EM-ML reconstruction
         sim = mmrprj.back_prj(attsino, scanner_params)
+        sim_inv = 1 / psf(sim)
 
         rndsct = rsng + ssng
         for i in trange(nitr, desc="MLEM",
@@ -288,14 +298,13 @@ def simulate_recon(
             #> then forward project the estimated image
             #> after which divide the measured sinogram by the estimated sinogram (forward projected)
             crrsino = mmraux.remgaps(measured_sino, txLUT, Cnt) / \
-                        (mmrprj.frwd_prj(eim, scanner_params, dev_out=True) + rndsct)
+                        (mmrprj.frwd_prj(psf(eim), scanner_params, dev_out=True) + rndsct)
 
             #> back project the correction factors sinogram
-            bim = mmrprj.back_prj(crrsino, scanner_params)
+            bim = psf(mmrprj.back_prj(crrsino, scanner_params))
 
             #> divide the back-projected image by the sensitivity image
-            bim[msk] /= sim[msk]
-            bim[~msk] = 0
+            bim *= sim_inv
 
             #> update the estimated image and remove NaNs
             eim *= msk*bim

--- a/niftypet/nipet/prj/src/prj_module.cu
+++ b/niftypet/nipet/prj/src/prj_module.cu
@@ -43,7 +43,7 @@ static PyMethodDef petprj_methods[] = {
 	 "PET forward projector."},
 	{"bprj",   back_prj,   METH_VARARGS,
 	"PET back projector." },
-	{"osem",   osem_rec,   METH_VARARGS, 
+	{"osem",   osem_rec,   METH_VARARGS,
 	 "OSEM reconstruction of PET data." },
 	{NULL, NULL, 0, NULL} // Sentinel
 };
@@ -75,7 +75,7 @@ PyMODINIT_FUNC PyInit_petprj(void) {
 #define CUDA_CHECK(ans) { gpuAssert((ans), __FILE__, __LINE__); }
 inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
 {
-   if (code != cudaSuccess) 
+   if (code != cudaSuccess)
    {
       fprintf(stderr,"GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
       if (abort) exit(code);
@@ -84,7 +84,7 @@ inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=t
 
 
 //==============================================================================
-// T R A N S A X I A L   P R O J E C T O R 
+// T R A N S A X I A L   P R O J E C T O R
 //------------------------------------------------------------------------------
 static PyObject *trnx_prj(PyObject *self, PyObject *args)
 {
@@ -125,7 +125,7 @@ static PyObject *trnx_prj(PyObject *self, PyObject *args)
 	PyObject* pd_s2c = PyDict_GetItemString(o_txLUT, "s2c");
 
 	//sino to crystal, crystals
-	PyArrayObject *p_s2c = NULL, *p_crs = NULL; 
+	PyArrayObject *p_s2c = NULL, *p_crs = NULL;
 	p_s2c = (PyArrayObject *)PyArray_FROM_OTF(pd_s2c, NPY_INT16, 	NPY_ARRAY_IN_ARRAY);
 	p_crs = (PyArrayObject *)PyArray_FROM_OTF(pd_crs, NPY_FLOAT32, 	NPY_ARRAY_IN_ARRAY);
 
@@ -133,7 +133,7 @@ static PyObject *trnx_prj(PyObject *self, PyObject *args)
 	//image object
 	PyArrayObject *p_im = NULL;
 	p_im = (PyArrayObject *)PyArray_FROM_OTF(o_im, NPY_FLOAT32, NPY_ARRAY_INOUT_ARRAY2);
-	
+
 	//output sino object
 	PyArrayObject *p_prjout = NULL;
 	p_prjout = (PyArrayObject *)PyArray_FROM_OTF(o_prjout, NPY_FLOAT32, NPY_ARRAY_INOUT_ARRAY2);
@@ -181,20 +181,20 @@ static PyObject *trnx_prj(PyObject *self, PyObject *args)
 	int N1crs = PyArray_DIM(p_crs, 1);
 	if (Cnt.LOG <= LOGDEBUG)
 		printf("\ni> N0crs=%d, N1crs=%d\n", N0crs, N1crs);
-	
+
 
 	float *im  = (float*)PyArray_DATA(p_im);
 	if (Cnt.LOG <= LOGDEBUG)
 		printf("i> forward-projection image dimensions: %d, %d, %d\n", PyArray_DIM(p_im, 0), PyArray_DIM(p_im, 1));
 
-	// input/output projection sinogram 
+	// input/output projection sinogram
 	float *prjout = (float*)PyArray_DATA(p_prjout);
 
-	// output sampling 
+	// output sampling
 	unsigned char *tv = (unsigned char*)PyArray_DATA(p_tv);
 	float *tt = (float*)PyArray_DATA(p_tt);
 
-	
+
 	// CUDA --------------------------------------------------------------------
 
 	// sets the device on which to calculate
@@ -255,7 +255,7 @@ static PyObject *trnx_prj(PyObject *self, PyObject *args)
 
 
 //==============================================================================
-// F O R W A R D   P R O J E C T O R 
+// F O R W A R D   P R O J E C T O R
 //------------------------------------------------------------------------------
 
 static PyObject *frwd_prj(PyObject *self, PyObject *args)
@@ -325,7 +325,7 @@ static PyObject *frwd_prj(PyObject *self, PyObject *args)
 	PyObject* pd_aw2ali = PyDict_GetItemString(o_txLUT, "aw2ali");
 
 	//sino to crystal, crystals
-	PyArrayObject *p_s2c = NULL, *p_crs = NULL, *p_aw2ali = NULL; 
+	PyArrayObject *p_s2c = NULL, *p_crs = NULL, *p_aw2ali = NULL;
 	p_s2c = (PyArrayObject *)PyArray_FROM_OTF(pd_s2c, NPY_INT16, 	NPY_ARRAY_IN_ARRAY);
 	p_crs = (PyArrayObject *)PyArray_FROM_OTF(pd_crs, NPY_FLOAT32, 	NPY_ARRAY_IN_ARRAY);
 
@@ -335,11 +335,11 @@ static PyObject *frwd_prj(PyObject *self, PyObject *args)
 	//image object
 	PyArrayObject *p_im = NULL;
 	p_im = (PyArrayObject *)PyArray_FROM_OTF(o_im, NPY_FLOAT32, NPY_ARRAY_IN_ARRAY);
-	
+
 	//subsets if using e.g., OSEM
 	PyArrayObject *p_subs = NULL;
 	p_subs = (PyArrayObject *)PyArray_FROM_OTF(o_subs, NPY_INT32, NPY_ARRAY_IN_ARRAY);
-	
+
 	//output sino object
 	PyArrayObject *p_prjout = NULL;
 	p_prjout = (PyArrayObject *)PyArray_FROM_OTF(o_prjout, NPY_FLOAT32, NPY_ARRAY_INOUT_ARRAY2);
@@ -418,7 +418,7 @@ static PyObject *frwd_prj(PyObject *self, PyObject *args)
 		subs = subs_;
 	}
 
-	// output projection sinogram 
+	// output projection sinogram
 	float *prjout = (float*)PyArray_DATA(p_prjout);
 
 	// sets the device on which to calculate
@@ -457,7 +457,7 @@ static PyObject *frwd_prj(PyObject *self, PyObject *args)
 
 
 //==============================================================================
-// B A C K   P R O J E C T O R 
+// B A C K   P R O J E C T O R
 //------------------------------------------------------------------------------
 static PyObject *back_prj(PyObject *self, PyObject *args)
 {
@@ -507,7 +507,7 @@ static PyObject *back_prj(PyObject *self, PyObject *args)
 	PyObject* pd_li2sn1 = PyDict_GetItemString(o_axLUT, "li2sn1");
 	PyObject* pd_li2nos = PyDict_GetItemString(o_axLUT, "li2nos");
 	PyObject* pd_li2rng = PyDict_GetItemString(o_axLUT, "li2rng");
-	
+
 	//transaxial sino LUTs:
 	PyObject* pd_crs = PyDict_GetItemString(o_txLUT, "crs");
 	PyObject* pd_s2c = PyDict_GetItemString(o_txLUT, "s2c");
@@ -522,9 +522,9 @@ static PyObject *back_prj(PyObject *self, PyObject *args)
 	p_li2sn  = (PyArrayObject *)PyArray_FROM_OTF(pd_li2sn,  NPY_INT16,	NPY_ARRAY_IN_ARRAY);
 	p_li2nos = (PyArrayObject *)PyArray_FROM_OTF(pd_li2nos, NPY_INT8, 	NPY_ARRAY_IN_ARRAY);
 	p_li2rng = (PyArrayObject *)PyArray_FROM_OTF(pd_li2rng, NPY_FLOAT32,NPY_ARRAY_IN_ARRAY);
-	
+
 	//sino to crystal, crystals
-	PyArrayObject *p_s2c = NULL, *p_crs = NULL, *p_aw2ali = NULL; 
+	PyArrayObject *p_s2c = NULL, *p_crs = NULL, *p_aw2ali = NULL;
 	p_s2c = (PyArrayObject *)PyArray_FROM_OTF(pd_s2c, NPY_INT16, 	NPY_ARRAY_IN_ARRAY);
 	p_crs = (PyArrayObject *)PyArray_FROM_OTF(pd_crs, NPY_FLOAT32, 	NPY_ARRAY_IN_ARRAY);
 
@@ -537,7 +537,7 @@ static PyObject *back_prj(PyObject *self, PyObject *args)
 	//subsets if using e.g., OSEM
 	PyArrayObject *p_subs = NULL;
 	p_subs = (PyArrayObject *)PyArray_FROM_OTF(o_subs, NPY_INT32, NPY_ARRAY_IN_ARRAY);
-	
+
 	//output back-projection image
 	PyArrayObject *p_bim = NULL;
 	p_bim = (PyArrayObject *)PyArray_FROM_OTF(o_bimg, NPY_FLOAT32, NPY_ARRAY_INOUT_ARRAY2);
@@ -677,7 +677,7 @@ static PyObject *osem_rec(PyObject *self, PyObject *args)
 	PyObject * o_rsng; //randoms
 	PyObject * o_ssng; //scatter
 	PyObject * o_nsng; //norm
-	PyObject * o_asng; //attenuation  
+	PyObject * o_asng; //attenuation
 
 					   //sensitivity image
 	PyObject * o_imgsens;
@@ -692,6 +692,8 @@ static PyObject *osem_rec(PyObject *self, PyObject *args)
 	Cnt.LOG = (char)PyLong_AsLong(pd_log);
 	PyObject* pd_span = PyDict_GetItemString(o_mmrcnst, "SPN");
 	Cnt.SPN = (char)PyLong_AsLong(pd_span);
+	PyObject* pd_sigma_rm = PyDict_GetItemString(o_mmrcnst, "SIGMA_RM");
+	Cnt.SIGMA_RM = (float)PyFloat_AsDouble(pd_sigma_rm);
 	PyObject* pd_devid = PyDict_GetItemString(o_mmrcnst, "DEVID");
 	Cnt.DEVID = (char)PyLong_AsLong(pd_devid);
 
@@ -740,11 +742,11 @@ static PyObject *osem_rec(PyObject *self, PyObject *args)
 	p_li2sn1 = (PyArrayObject *)PyArray_FROM_OTF(pd_li2sn1, NPY_INT16, NPY_ARRAY_IN_ARRAY);
 	p_li2nos = (PyArrayObject *)PyArray_FROM_OTF(pd_li2nos, NPY_INT8, NPY_ARRAY_IN_ARRAY);
 	p_li2rng = (PyArrayObject *)PyArray_FROM_OTF(pd_li2rng, NPY_FLOAT32, NPY_ARRAY_IN_ARRAY);
-	
+
 	//2D sino index LUT:
 	PyArrayObject *p_aw2ali = NULL;
 	p_aw2ali = (PyArrayObject *)PyArray_FROM_OTF(pd_aw2ali, NPY_INT32, NPY_ARRAY_IN_ARRAY);
-	
+
 	//sino to crystal, crystals
 	PyArrayObject *p_s2c = NULL, *p_crs = NULL;
 	p_s2c = (PyArrayObject *)PyArray_FROM_OTF(pd_s2c, NPY_INT16, NPY_ARRAY_IN_ARRAY);

--- a/niftypet/nipet/prj/src/recon.cu
+++ b/niftypet/nipet/prj/src/recon.cu
@@ -520,7 +520,7 @@ void osem(float *imgout,
 
 		//forward project
 		cudaMemset(d_esng, 0, Nprj*snno * sizeof(float));
-		rec_fprj(d_esng, d_imgout_rm, &d_subs[i*Nprj + 1], subs[i*Nprj], d_tt, d_tv, li2rng, li2sn, li2nos, Cnt);
+		rec_fprj(d_esng, Cnt.SIGMA_RM>0 ? d_imgout_rm : d_imgout, &d_subs[i*Nprj + 1], subs[i*Nprj], d_tt, d_tv, li2rng, li2sn, li2nos, Cnt);
 
 		//add the randoms+scatter
 		d_sneladd(d_esng, d_rsng, &d_subs[i*Nprj + 1], subs[i*Nprj], snno);

--- a/niftypet/nipet/prj/src/recon.cu
+++ b/niftypet/nipet/prj/src/recon.cu
@@ -346,7 +346,9 @@ void osem(float *imgout,
 	}
 
 	// resolution modelling current image
-	d_convolve3d(d_convtmp, d_imgout, d_knlrm, SZ_IMX, SZ_IMY, SZ_IMZ, knlW, knlW, knlW);
+	float *d_imgout_rm;   HANDLE_ERROR(cudaMalloc(&d_imgout_rm, SZ_IMX*SZ_IMY*SZ_IMZ * sizeof(float)));
+	HANDLE_ERROR(cudaMemcpy(d_imgout_rm, d_imgout, SZ_IMX*SZ_IMY*SZ_IMZ * sizeof(float), cudaMemcpyDeviceToDevice));
+	d_convolve3d(d_convtmp, d_imgout_rm, d_knlrm, SZ_IMX, SZ_IMY, SZ_IMZ, knlW, knlW, knlW);
 
 	//--back-propagated image
 
@@ -364,7 +366,7 @@ void osem(float *imgout,
 
 		//forward project
 		cudaMemset(d_esng, 0, Nprj*snno * sizeof(float));
-		rec_fprj(d_esng, d_imgout, &d_subs[i*Nprj + 1], subs[i*Nprj], d_tt, d_tv, li2rng, li2sn, li2nos, Cnt);
+		rec_fprj(d_esng, d_imgout_rm, &d_subs[i*Nprj + 1], subs[i*Nprj], d_tt, d_tv, li2rng, li2sn, li2nos, Cnt);
 
 		//add the randoms+scatter
 		d_sneladd(d_esng, d_rsng, &d_subs[i*Nprj + 1], subs[i*Nprj], snno);
@@ -404,6 +406,7 @@ void osem(float *imgout,
 	cudaFree(d_knlrm);
 	cudaFree(d_convtmp);
 	cudaFree(d_imgout);
+	cudaFree(d_imgout_rm);
 	cudaFree(d_bimg);
 	cudaFree(d_rcnmsk);
 }

--- a/niftypet/nipet/prj/src/recon.cu
+++ b/niftypet/nipet/prj/src/recon.cu
@@ -2,8 +2,9 @@
 CUDA C extention for Python
 Provides functionality for PET image reconstruction.
 
-author: Pawel Markiewicz
-Copyrights: 2018
+Copyrights:
+2018-2020 Pawel Markiewicz
+2020 Casper da Costa-Luis
 ------------------------------------------------------------------------*/
 #include "recon.h"
 #include <assert.h>
@@ -167,7 +168,7 @@ __global__ void cnv_columns(float *d_Dst, float *d_Src, int imageW, int imageH, 
 }
 
 /// d_buff: temporary image buffer
-void d_conv(float *d_buff, float *d_imgout, float *d_imgint, int Nvk, int Nvj, int Nvi, bool inplace = false) {
+void d_conv(float *d_buff, float *d_imgout, float *d_imgint, int Nvk, int Nvj, int Nvi) {
   assert(d_imgout != d_imgint);
   assert(ROWS_BLOCKDIM_X * ROWS_HALO_STEPS >= KERNEL_RADIUS);
   assert(Nvk % (ROWS_RESULT_STEPS * ROWS_BLOCKDIM_X) == 0);

--- a/niftypet/nipet/prj/src/recon.cu
+++ b/niftypet/nipet/prj/src/recon.cu
@@ -369,8 +369,7 @@ void osem(float *imgout,
 		if (Cnt.LOG <= LOGDEBUG) printf("<> subset %d-th <>\n", i);
 
 		//resolution modelling current image
-		HANDLE_ERROR(cudaMemcpy(d_imgout_rm, d_imgout, SZ_IMX*SZ_IMY*SZ_IMZ * sizeof(float), cudaMemcpyDeviceToDevice));
-		d_convolve3d(d_convtmp, d_imgout_rm, d_knlrm, SZ_IMX, SZ_IMY, SZ_IMZ, knlW, knlW, knlW, true);
+		d_convolve3d(d_imgout_rm, d_imgout, d_knlrm, SZ_IMX, SZ_IMY, SZ_IMZ, knlW, knlW, knlW, false);
 
 		//forward project
 		cudaMemset(d_esng, 0, Nprj*snno * sizeof(float));

--- a/niftypet/nipet/prj/src/recon.h
+++ b/niftypet/nipet/prj/src/recon.h
@@ -9,7 +9,7 @@
 #define RECON_H
 
 /* separable convolution */
-#define KERNEL_RADIUS 4
+#define KERNEL_RADIUS 5
 #define KERNEL_LENGTH (2*KERNEL_RADIUS + 1)
 
 // Column convolution filter

--- a/niftypet/nipet/prj/src/recon.h
+++ b/niftypet/nipet/prj/src/recon.h
@@ -9,7 +9,7 @@
 #define RECON_H
 
 /* separable convolution */
-#define KERNEL_RADIUS 8
+#define KERNEL_RADIUS 4
 #define KERNEL_LENGTH (2*KERNEL_RADIUS + 1)
 
 // Column convolution filter

--- a/niftypet/nipet/prj/src/recon.h
+++ b/niftypet/nipet/prj/src/recon.h
@@ -8,6 +8,21 @@
 #ifndef RECON_H
 #define RECON_H
 
+/* separable convolution */
+#define KERNEL_RADIUS 8
+#define KERNEL_LENGTH (2*KERNEL_RADIUS + 1)
+
+// Column convolution filter
+#define   COLUMNS_BLOCKDIM_X 8
+#define   COLUMNS_BLOCKDIM_Y 8
+#define COLUMNS_RESULT_STEPS 8
+#define   COLUMNS_HALO_STEPS 1
+
+// Row convolution filter
+#define   ROWS_BLOCKDIM_X 8
+#define   ROWS_BLOCKDIM_Y 8
+#define ROWS_RESULT_STEPS 8
+#define   ROWS_HALO_STEPS 1
 
 void osem(float *imgout,
 	bool  *rcnmsk,

--- a/niftypet/nipet/src/scanner_0.h
+++ b/niftypet/nipet/src/scanner_0.h
@@ -61,6 +61,7 @@ struct Cnst {
 	char LOG; //different levels of verbose/logging like in Python's logging package
 
 
+	float SIGMA_RM; // resolution modelling sigma
 	// float RE;    //effective ring diameter
 	// float ICOSSTP;
 	

--- a/resources/resources.py
+++ b/resources/resources.py
@@ -153,6 +153,7 @@ SZ_VOXZ = 0.203125
 # SZ_VOXY = 0.1669
 # SZ_VOXZ = 0.203125
 #~~~
+SIGMA_RM = 0
 
 #~~~
 # inverse size
@@ -364,6 +365,7 @@ def get_mmr_constants():
         'SO_VXZ':SO_VXZ,
         'SO_VXY':SO_VXY,
         'SO_VXX':SO_VXX,
+        'SIGMA_RM':SIGMA_RM, # resolution modelling sigma
 
         'NTT':NTT,
         'NTV':NTV,


### PR DESCRIPTION
- [x] add a new `fwhm_rm : float` argument
  + add `SIGMA_RM` to `resources.py` & `Cnt`
  + in future, this could also support a custom kernel
  + [x] use a faster separable convolution
    * profiling results for 1 iteration: f_prj: 120ms, b_prj: 350ms, filter: 35x2=70ms, scatter: the enemy
  + [x] make sure `fwhm_rm=0` doesn't do any filtering
  + [ ] use `fwhm_rm=2.5`mm by default? Better than nothing for Siddon projectors (see images below)
- [x] update `mmrrec`
- [x] update `mmrsim`
- [x] prevent nearly-zero division causing `inf`

# Images

Gaussian FWHM [mm]: Left: 2.5, Right: 4.5

**Using 3D filter** 969fc2a

![image](https://user-images.githubusercontent.com/10780059/96166665-2cc90200-0f16-11eb-90ec-d3c431a76f34.png)

**Using separable filter** 6df9dfd (see diff 969fc2a...6df9dfd)

![image](https://user-images.githubusercontent.com/10780059/96325387-3e4a0100-101f-11eb-9760-34e0b5d81ee7.png)

Profiling (extra time is mostly padding & unpadding Z 127<->128)

![image](https://user-images.githubusercontent.com/10780059/96337363-88160400-107e-11eb-9f75-42cf392d234d.png)

**Comparison to raw Siddon** a19133c (`fwhm_rm in [0, 2.5, 4.5]`)

![image](https://user-images.githubusercontent.com/10780059/96326139-098d7800-1026-11eb-8cc0-aa378a1321cd.png)